### PR TITLE
Adapt chipsInput styling

### DIFF
--- a/R/input-chips.R
+++ b/R/input-chips.R
@@ -12,7 +12,7 @@ chipsInput <- function(inputId, label=NULL, placeholder=NULL, chips=list()) {
     tags$div(class="shinyinvoer-chips-input",
              id=inputId,
              `data-chips`=jsonlite::toJSON(chips),
-             tags$label(label),
+             tags$label(class = "control-label", label),
              tags$div(class="chip-container",
                       tags$div(class="chip-list",
                                tags$div(class="chip-input-container",

--- a/inst/lib/chip-input/chip-input.css
+++ b/inst/lib/chip-input/chip-input.css
@@ -1,3 +1,7 @@
+.shinyinvoer-chips-input {
+	margin-bottom: 13px;
+}
+
 .chip-container {
   border-bottom: 2px solid #edf2f7;
   display: flex;


### PR DESCRIPTION
Add a margin-bottom for class `shinyinvoer-chips-input` and give assign shiny's `control-label` class to the label of `chipsInput`.